### PR TITLE
Issue 26

### DIFF
--- a/rabbit/consumer_test.go
+++ b/rabbit/consumer_test.go
@@ -56,7 +56,7 @@ func Test_getHeaders(t *testing.T) {
 			},
 		},
 		{
-			"with message headers x-death empty",
+			"with message headers x-death",
 			amqp.Delivery{
 				Body: []byte(`foooo`),
 				Headers: amqp.Table{

--- a/rabbit/consumer_test.go
+++ b/rabbit/consumer_test.go
@@ -1,0 +1,85 @@
+package rabbit
+
+import (
+	"testing"
+
+	"github.com/streadway/amqp"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_getHeaders(t *testing.T) {
+	tests := []struct {
+		name string
+		args amqp.Delivery
+		want map[string]string
+	}{
+		{
+			"with empty headers",
+			amqp.Delivery{Body: []byte(`foooo`)},
+			map[string]string{
+				"Content-Encoding": "",
+				"Content-Type":     "",
+				"Correlation-Id":   "",
+				"Message-Id":       "",
+			},
+		},
+		{
+			"with headers",
+			amqp.Delivery{
+				ContentEncoding: "compress, gzip",
+				ContentType:     "application/json",
+				CorrelationId:   "id-12334455",
+				MessageId:       "12345566",
+				Body:            []byte(`foooo`),
+			},
+			map[string]string{
+				"Content-Encoding": "compress, gzip",
+				"Content-Type":     "application/json",
+				"Correlation-Id":   "id-12334455",
+				"Message-Id":       "12345566",
+			},
+		},
+		{
+			"with message headers x-death empty",
+			amqp.Delivery{
+				Body: []byte(`foooo`),
+				Headers: amqp.Table{
+					"x-death": []amqp.Table{},
+				},
+			},
+			map[string]string{
+				"Content-Encoding":    "",
+				"Content-Type":        "",
+				"Correlation-Id":      "",
+				"Message-Id":          "",
+				"Message-Death-Count": "0",
+			},
+		},
+		{
+			"with message headers x-death empty",
+			amqp.Delivery{
+				Body: []byte(`foooo`),
+				Headers: amqp.Table{
+					"x-death": []amqp.Table{
+						amqp.Table{"time": "2018-02-13T17:50:26-02:00", "count": 4, "exchange": "fallback", "queue": "fallback", "reason": "expired"},
+						amqp.Table{"time": "2018-02-13T17:50:34-02:00", "count": 1, "exchange": "fallback", "queue": "fallback", "reason": "rejected"},
+						amqp.Table{"time": "2018-02-13T17:45:26-02:00", "count": 5, "exchange": "fallback", "queue": "GenerateReport", "reason": "rejected"},
+					},
+				},
+			},
+			map[string]string{
+				"Content-Encoding":    "",
+				"Content-Type":        "",
+				"Correlation-Id":      "",
+				"Message-Id":          "",
+				"Message-Death-Count": "6",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getHeaders(tt.args)
+			require.Exactly(t, tt.want, got)
+		})
+	}
+}

--- a/rabbit/consumer_test.go
+++ b/rabbit/consumer_test.go
@@ -61,9 +61,9 @@ func Test_getHeaders(t *testing.T) {
 				Body: []byte(`foooo`),
 				Headers: amqp.Table{
 					"x-death": []amqp.Table{
-						amqp.Table{"time": "2018-02-13T17:50:26-02:00", "count": 4, "exchange": "fallback", "queue": "fallback", "reason": "expired"},
-						amqp.Table{"time": "2018-02-13T17:50:34-02:00", "count": 1, "exchange": "fallback", "queue": "fallback", "reason": "rejected"},
-						amqp.Table{"time": "2018-02-13T17:45:26-02:00", "count": 5, "exchange": "fallback", "queue": "GenerateReport", "reason": "rejected"},
+						{"time": "2018-02-13T17:50:26-02:00", "count": 4, "exchange": "fallback", "queue": "fallback", "reason": "expired"},
+						{"time": "2018-02-13T17:50:34-02:00", "count": 1, "exchange": "fallback", "queue": "fallback", "reason": "rejected"},
+						{"time": "2018-02-13T17:45:26-02:00", "count": 5, "exchange": "fallback", "queue": "GenerateReport", "reason": "rejected"},
 					},
 				},
 			},

--- a/rabbit/consumer_test.go
+++ b/rabbit/consumer_test.go
@@ -48,11 +48,10 @@ func Test_getHeaders(t *testing.T) {
 				},
 			},
 			map[string]string{
-				"Content-Encoding":    "",
-				"Content-Type":        "",
-				"Correlation-Id":      "",
-				"Message-Id":          "",
-				"Message-Death-Count": "0",
+				"Content-Encoding": "",
+				"Content-Type":     "",
+				"Correlation-Id":   "",
+				"Message-Id":       "",
 			},
 		},
 		{
@@ -60,19 +59,19 @@ func Test_getHeaders(t *testing.T) {
 			amqp.Delivery{
 				Body: []byte(`foooo`),
 				Headers: amqp.Table{
-					"x-death": []amqp.Table{
-						{"time": "2018-02-13T17:50:26-02:00", "count": 4, "exchange": "fallback", "queue": "fallback", "reason": "expired"},
-						{"time": "2018-02-13T17:50:34-02:00", "count": 1, "exchange": "fallback", "queue": "fallback", "reason": "rejected"},
-						{"time": "2018-02-13T17:45:26-02:00", "count": 5, "exchange": "fallback", "queue": "GenerateReport", "reason": "rejected"},
+					"x-death": []interface{}{
+						amqp.Table{"time": "2018-02-13T17:50:26-02:00", "count": int64(4), "exchange": "fallback", "queue": "fallback", "reason": "expired"},
+						amqp.Table{"time": "2018-02-13T17:50:34-02:00", "count": int64(1), "exchange": "fallback", "queue": "fallback", "reason": "rejected"},
+						amqp.Table{"time": "2018-02-13T17:45:26-02:00", "count": int64(5), "exchange": "fallback", "queue": "GenerateReport", "reason": "rejected"},
 					},
 				},
 			},
 			map[string]string{
-				"Content-Encoding":    "",
-				"Content-Type":        "",
-				"Correlation-Id":      "",
-				"Message-Id":          "",
-				"Message-Death-Count": "6",
+				"Content-Encoding": "",
+				"Content-Type":     "",
+				"Correlation-Id":   "",
+				"Message-Id":       "",
+				"Message-Deaths":   "6",
 			},
 		},
 	}

--- a/rabbit/integration_test.go
+++ b/rabbit/integration_test.go
@@ -230,7 +230,7 @@ type mockRunner struct {
 	exitStatus int
 }
 
-func (m *mockRunner) Process(ctx context.Context, b []byte) int {
+func (m *mockRunner) Process(ctx context.Context, b []byte, headers map[string]string) int {
 	atomic.AddInt64(&m.count, 1)
 	return m.exitStatus
 }

--- a/runner/cmd.go
+++ b/runner/cmd.go
@@ -19,7 +19,7 @@ type command struct {
 	ignoreOutput bool
 }
 
-func (c *command) Process(ctx context.Context, b []byte) int {
+func (c *command) Process(ctx context.Context, b []byte, headers map[string]string) int {
 	cmd := exec.CommandContext(ctx, c.cmd, c.args...)
 	stdin, err := cmd.StdinPipe()
 	if err != nil {

--- a/runner/cmd_test.go
+++ b/runner/cmd_test.go
@@ -70,7 +70,7 @@ func Test_command_Process(t *testing.T) {
 				ctx, cancel = context.WithTimeout(ctx, 100*time.Millisecond)
 				defer cancel()
 			}
-			if got := c.Process(ctx, tt.args.b); got != tt.want {
+			if got := c.Process(ctx, tt.args.b, map[string]string{}); got != tt.want {
 				t.Errorf("command.Process() = %v, want %v", got, tt.want)
 			}
 			logger.Close()

--- a/runner/http.go
+++ b/runner/http.go
@@ -21,12 +21,15 @@ type httpRunner struct {
 	returnOn5xx  int
 }
 
-func (p *httpRunner) Process(ctx context.Context, b []byte) int {
+func (p *httpRunner) Process(ctx context.Context, b []byte, headers map[string]string) int {
 	contentReader := bytes.NewReader(b)
 	req, err := http.NewRequest("POST", p.url, contentReader)
 	if err != nil {
 		p.log.Error("error creating the request", event.KV("error", err))
 		return ExitRetry
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
 	}
 	for k, v := range p.headers {
 		req.Header.Set(k, v)

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -23,7 +23,7 @@ const (
 
 // Runnable represent an runnable used by consumers to handle messages.
 type Runnable interface {
-	Process(context.Context, []byte) int
+	Process(context.Context, []byte, map[string]string) int
 }
 
 // Options is a composition os all options used internally by runners.


### PR DESCRIPTION
Send headers for correlation.
Currently, we are sending these headers:
`Content-Encoding`, `Content-Type`, `Correlation-Id`, `Message-Id` and `Message-Death-Count`

closes #26 