### PR TITLE
Update cannon.yml

### DIFF
--- a/cannon.yml.dist
+++ b/cannon.yml.dist
@@ -40,7 +40,7 @@ rabbitmq:
     upload_picture:
       connection: default
       workers: 1                 # Number of concurrent messages processed. Defaults to 1.
-      prefetch_count: 10         # Prefetch message count per worker.
+      prefetch_count: 10         # Prefetch message count per consumer. Must be greater or equal than workers.
       dead_letter: fallback
       queue:
         name: "upload-picture"


### PR DESCRIPTION
"workers" is the number of workers in pool.
"prefetch_count" is the number of messages that will be prefetched by consumer. So it must be greater or equal than "worker", otherwise only "prefetch_count" number of workers will receive messages.