### PR TITLE
Remove 'git' dependency from .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,8 +37,6 @@ nfpm:
   formats:
   - deb
   - rpm
-  dependencies:
-  - git
   recommends:
   - rpm
 snapcraft:


### PR DESCRIPTION
DEB/RPM package shouldn't depend on git